### PR TITLE
Summary Details Scree: show real Recommendations and enable navigation when a recommendation is clicked

### DIFF
--- a/app/src/main/java/app/books/tanga/domain/summary/SummaryInteractor.kt
+++ b/app/src/main/java/app/books/tanga/domain/summary/SummaryInteractor.kt
@@ -84,7 +84,12 @@ class SummaryInteractor @Inject constructor(
                 val summaries = getSummariesByCategory(it).getOrThrow()
                 recommendedSummaries.addAll(summaries)
             }
-            recommendedSummaries.shuffled().take(4)
+            // Remove duplicates and shuffle the list then take only 4 summaries
+            recommendedSummaries
+                .toSet()
+                .toList()
+                .shuffled()
+                .take(4)
         }
     }
 

--- a/app/src/main/java/app/books/tanga/feature/summary/SummaryNavigation.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/SummaryNavigation.kt
@@ -9,7 +9,9 @@ import app.books.tanga.feature.summary.details.SummaryDetailsScreen
 import app.books.tanga.navigation.NavigationScreen
 
 fun NavGraphBuilder.summaryDetails(
-    onBackClicked: () -> Unit, onPlayClicked: () -> Unit
+    onBackClicked: () -> Unit,
+    onPlayClicked: () -> Unit,
+    onRecommendationClicked: (String) -> Unit
 ) {
     composable(
         route = NavigationScreen.SummaryDetails.route,
@@ -22,7 +24,8 @@ fun NavGraphBuilder.summaryDetails(
                 .arguments
                 ?.getString(NavigationScreen.SummaryDetails.SUMMARY_ID_KEY)!!,
             onBackClicked = onBackClicked,
-            onPlayClicked = onPlayClicked
+            onPlayClicked = onPlayClicked,
+            onRecommendationClicked = onRecommendationClicked
         )
     }
 }

--- a/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsScreen.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsScreen.kt
@@ -57,7 +57,8 @@ fun SummaryDetailsScreen(
     summaryId: String,
     viewModel: SummaryDetailsViewModel = hiltViewModel(),
     onBackClicked: () -> Unit,
-    onPlayClicked: () -> Unit
+    onPlayClicked: () -> Unit,
+    onRecommendationClicked: (String) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     LaunchedEffect(Unit) {
@@ -88,7 +89,10 @@ fun SummaryDetailsScreen(
             PurchaseButton()
 
             Spacer(modifier = Modifier.height(LocalSpacing.current.medium))
-            Recommendations()
+            Recommendations(
+                recommendations = state.recommendations,
+                onRecommendationClicked = onRecommendationClicked
+            )
         }
     }
 }
@@ -255,10 +259,11 @@ private fun SummaryBasicInfo(
             )
             Spacer(modifier = Modifier.width(5.dp))
             Text(
+                modifier = Modifier.padding(top = 4.dp),
                 text = stringResource(id = R.string.summary_duration, duration),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(top = 4.dp)
+                fontWeight = FontWeight.SemiBold,
             )
         }
     }
@@ -306,10 +311,11 @@ private fun PurchaseButton() {
 
 
 @Composable
-fun Recommendations(modifier: Modifier = Modifier) {
-    val recommendedSummaries = remember {
-        FakeData.allSummaries().shuffled().take(4)
-    }
+fun Recommendations(
+    modifier: Modifier = Modifier,
+    recommendations: List<SummaryUi>,
+    onRecommendationClicked: (String) -> Unit
+) {
     Column(modifier = modifier.padding(LocalSpacing.current.medium)) {
         Text(
             text = stringResource(id = R.string.summary_details_recommendations),
@@ -320,8 +326,10 @@ fun Recommendations(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.height(LocalSpacing.current.medium))
         SummaryRow(
-            summaries = recommendedSummaries
-        ) { /*TODO*/ }
+            summaries = recommendations
+        ) { summaryId ->
+            onRecommendationClicked(summaryId)
+        }
     }
 }
 

--- a/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsViewModel.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsViewModel.kt
@@ -23,6 +23,9 @@ class SummaryDetailsViewModel @Inject constructor(
         MutableStateFlow(SummaryDetailsUiState())
     val state: StateFlow<SummaryDetailsUiState> = _state.asStateFlow()
 
+    /**
+     * Load the summary with the given id then load the recommendations for this summary
+     */
     fun loadSummary(summaryId: String) {
         viewModelScope.launch {
             summaryInteractor.getSummary(summaryId).onSuccess { summary ->

--- a/app/src/main/java/app/books/tanga/navigation/MainNavigationGraph.kt
+++ b/app/src/main/java/app/books/tanga/navigation/MainNavigationGraph.kt
@@ -27,7 +27,8 @@ fun MainNavigationGraph(
         bottomBarNavGraph(navController = navController)
         summaryDetails(
             onBackClicked = { navController.popBackStack() },
-            onPlayClicked = { navController.toPlaySummaryAudio() }
+            onPlayClicked = { navController.toPlaySummaryAudio() },
+            onRecommendationClicked = { summaryId -> navController.toSummaryDetails(summaryId) }
         )
         search()
         playSummaryAudio { navController.popBackStack()}


### PR DESCRIPTION
* **Efficiency boost for summary recommendations**
  The code in `SummaryInteractor.kt` has been enhanced by removing duplicate recommendation summaries, randomly arranging the list (shuffling), and presenting the top 4 suggestions. This means users will now receive a more diverse range of suggestions. 

* **Interaction improvements in summary navigation**
  In the `SummaryNavigation.kt` and `SummaryDetailsScreen.kt` units, a new parameter named `onRecommendationClicked` was introduced. With this addition, when a user clicks on a recommended summary, their action triggers a specific response, improving interactivity and user experience. 

* **Added comment for clarity in loading summaries**
  A comment has been inserted into `SummaryDetailsViewModel.kt` to clarify that the `loadSummary` function loads a given summary and its recommendations. This comment makes understanding the code easier for anyone reviewing or debugging it in the future.

* **Improved navigation logic for recommendation click**
  In `MainNavigationGraph.kt`, the `onRecommendationClicked` parameter has been introduced to the `summaryDetails` function. This includes user-friendly navigation logic when a recommendation is clicked, providing better user navigability and functionality.


## screenshot
![Screenshot_20230921_135841](https://github.com/rygelouv/Tanga/assets/7549316/36694bc4-88cf-442e-b86f-19092419c415)
