### PR TITLE
Summary Details Screen: add loader animation

### DIFF
--- a/app/src/main/java/app/books/tanga/AppUtils.kt
+++ b/app/src/main/java/app/books/tanga/AppUtils.kt
@@ -2,15 +2,24 @@ package app.books.tanga
 
 import android.content.Context
 import android.content.Intent
-import app.books.tanga.feature.summary.SummaryUi
 
-fun shareSummary(summary: SummaryUi, context: Context) {
+/**
+ * Utility function to share a summary
+ */
+fun shareSummary(
+    context: Context,
+    summaryTitle: String,
+    summaryAuthor: String,
+    url: String = "https://ibb.co/bKn9yf6"
+) {
     val sendIntent: Intent = Intent().apply {
         action = Intent.ACTION_SEND
         putExtra(
             Intent.EXTRA_TEXT,
-            context.getString(R.string.summary_details_share_message,
-                summary.title, summary.author, "https://ibb.co/bKn9yf6")
+            context.getString(
+                R.string.summary_details_share_message,
+                summaryTitle, summaryAuthor, url
+            )
         )
         type = "text/plain"
     }

--- a/app/src/main/java/app/books/tanga/common/ui/ShimmerComponents.kt
+++ b/app/src/main/java/app/books/tanga/common/ui/ShimmerComponents.kt
@@ -1,0 +1,68 @@
+package app.books.tanga.common.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
+
+/**
+ * A list of summary shimmer placeholders
+ */
+@Composable
+fun ShimmerSummaryListRow(brush: Brush) {
+    Row {
+        repeat(4) {
+            ShimmerSummaryItemSmall(modifier = Modifier, brush = brush)
+            Spacer(modifier = Modifier.width(10.dp))
+        }
+    }
+}
+
+/**
+ * A summary shimmer item placeholder
+ */
+@Composable
+fun ShimmerSummaryItemSmall(modifier: Modifier, brush: Brush) {
+    Column(
+        modifier = modifier
+            .width(134.dp)
+            .height(250.dp),
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(brush)
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Spacer(modifier = Modifier
+            .fillMaxWidth()
+            .height(20.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush))
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        Spacer(modifier = Modifier
+            .fillMaxWidth(fraction = 0.7f)
+            .height(20.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(brush))
+    }
+}

--- a/app/src/main/java/app/books/tanga/feature/home/HomeShimmerLoader.kt
+++ b/app/src/main/java/app/books/tanga/feature/home/HomeShimmerLoader.kt
@@ -12,19 +12,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import app.books.tanga.common.ui.ShimmerSummaryListRow
+import app.books.tanga.common.ui.ShimmerSummaryItemSmall
 
 @Composable
 fun AnimatedShimmerLoader(modifier: Modifier) {
@@ -55,53 +52,8 @@ fun AnimatedShimmerLoader(modifier: Modifier) {
     Column(modifier = modifier.background(color = MaterialTheme.colorScheme.background)) {
         repeat(3) {
             Spacer(modifier = Modifier.height(24.dp))
-            AnimatedShimmerRow(brush)
+            ShimmerSummaryListRow(brush)
         }
-    }
-}
-
-@Composable
-fun AnimatedShimmerRow(brush: Brush) {
-    Row {
-        repeat(4) {
-            ShimmerSummaryItemSmall(modifier = Modifier, brush = brush)
-            Spacer(modifier = Modifier.width(10.dp))
-        }
-    }
-}
-
-@Composable
-fun ShimmerSummaryItemSmall(modifier: Modifier, brush: Brush) {
-    Column(
-        modifier = modifier
-            .width(134.dp)
-            .height(250.dp),
-        horizontalAlignment = Alignment.Start,
-        verticalArrangement = Arrangement.Top
-    ) {
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(200.dp)
-                .clip(RoundedCornerShape(10.dp))
-                .background(brush)
-        )
-
-        Spacer(modifier = Modifier.height(10.dp))
-
-        Spacer(modifier = Modifier
-            .fillMaxWidth()
-            .height(20.dp)
-            .clip(RoundedCornerShape(5.dp))
-            .background(brush))
-
-        Spacer(modifier = Modifier.height(10.dp))
-
-        Spacer(modifier = Modifier
-            .fillMaxWidth(fraction = 0.7f)
-            .height(20.dp)
-            .clip(RoundedCornerShape(5.dp))
-            .background(brush))
     }
 }
 

--- a/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsShimmerLoader.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsShimmerLoader.kt
@@ -1,0 +1,129 @@
+package app.books.tanga.feature.summary.details
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import app.books.tanga.common.ui.ShimmerSummaryItemSmall
+import app.books.tanga.common.ui.ShimmerSummaryListRow
+import app.books.tanga.core_ui.theme.LocalSpacing
+
+@Composable
+fun SummaryDetailsShimmerLoader() {
+    val shimmerColors = listOf(
+        Color.LightGray.copy(alpha = 0.6f),
+        Color.LightGray.copy(alpha = 0.2f),
+        Color.LightGray.copy(alpha = 0.6f),
+    )
+
+    val transition = rememberInfiniteTransition(label = "Summary list Shimmer transition")
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutSlowInEasing
+            ),
+            repeatMode = RepeatMode.Restart
+        ), label = "Summary list Shimmer translate animation"
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset.Zero,
+        end = Offset(x = translateAnimation.value, y = translateAnimation.value)
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(LocalSpacing.current.medium)
+    ) {
+        Spacer(modifier = Modifier.height(LocalSpacing.current.extraExtraLarge))
+
+        /* Start header zone (image + title + author) */
+        Row {
+            ShimmerSummaryItemSmall(modifier = Modifier, brush = brush)
+
+            Spacer(modifier = Modifier.width(LocalSpacing.current.medium))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(LocalSpacing.current.medium),
+            ) {
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(20.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(brush)
+                )
+
+                Spacer(modifier = Modifier.width(LocalSpacing.current.large))
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.7f)
+                        .height(20.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(brush)
+                )
+            }
+        }
+        /* End header zone */
+
+        Spacer(modifier = Modifier.height(LocalSpacing.current.extraLarge))
+
+        /* Start introduction zone */
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush)
+        )
+
+        Spacer(modifier = Modifier.height(LocalSpacing.current.small))
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush)
+        )
+
+        Spacer(modifier = Modifier.height(LocalSpacing.current.small))
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(20.dp)
+                .clip(RoundedCornerShape(5.dp))
+                .background(brush)
+        )
+        /* End introduction zone */
+
+        Spacer(modifier = Modifier.height(LocalSpacing.current.extraLarge))
+
+        /* Start recommendations zone */
+        ShimmerSummaryListRow(brush)
+        /* End recommendations zone */
+    }
+}

--- a/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsUiContract.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsUiContract.kt
@@ -1,5 +1,6 @@
 package app.books.tanga.feature.summary.details
 
+import app.books.tanga.common.ui.ProgressState
 import app.books.tanga.feature.summary.SummaryUi
 
 /**
@@ -8,6 +9,7 @@ import app.books.tanga.feature.summary.SummaryUi
  * @param recommendations the list of recommended summaries related to the current summary
  */
 data class SummaryDetailsUiState(
+    val progressState: ProgressState = ProgressState.Hide,
     val summary: SummaryUi? = null,
     val isFavorite: Boolean = false,
     val recommendations: List<SummaryUi> = emptyList()

--- a/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsViewModel.kt
+++ b/app/src/main/java/app/books/tanga/feature/summary/details/SummaryDetailsViewModel.kt
@@ -3,6 +3,7 @@ package app.books.tanga.feature.summary.details
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.books.tanga.common.ui.ProgressState
 import app.books.tanga.domain.summary.Summary
 import app.books.tanga.domain.summary.SummaryInteractor
 import app.books.tanga.feature.summary.toSummaryUi
@@ -20,7 +21,7 @@ class SummaryDetailsViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _state: MutableStateFlow<SummaryDetailsUiState> =
-        MutableStateFlow(SummaryDetailsUiState())
+        MutableStateFlow(SummaryDetailsUiState(progressState = ProgressState.Show))
     val state: StateFlow<SummaryDetailsUiState> = _state.asStateFlow()
 
     /**
@@ -31,6 +32,7 @@ class SummaryDetailsViewModel @Inject constructor(
             summaryInteractor.getSummary(summaryId).onSuccess { summary ->
                 _state.update {
                     it.copy(
+                        progressState = ProgressState.Hide,
                         summary = summary.toSummaryUi(),
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,5 +55,5 @@
     <string name="summary_details_watch">Watch</string>
     <string name="summary_details_visualize">Visualize</string>
     <string name="summary_details_author">Author</string>
-    <string name="summary_details_share_message">Read, list or watch the book summary \"%1$s\" by %2$s on Tanga App. \n %3$s</string>
+    <string name="summary_details_share_message">Read, list or watch a summary of the book \"%1$s\" by %2$s on Tanga App.\n %3$s</string>
 </resources>


### PR DESCRIPTION
* **Expanded Sharing Ability**
Added a new utility feature, which simplifies the sharing of a summary by specifically including title, author, and URL information.

* **Added Loading Placeholders**
In the file named `ShimmerComponents.kt`, new functions have been introduced to display shimmer loading placeholders. These placeholders give users visual feedback that content is loading. 

* **Renamed Shimmer Loader**
The `ShimmerLoader.kt` file has been renamed to `HomeShimmerLoader.kt` for clarity and easier identification.

* **Improved Summary Detail Screen**
Changes to `SummaryDetailsScreen.kt` include:
    * Conditional rendering: This now allows the system to autonomously decide whether to show a loading placeholder or the actual content based on the loading progress.
    * More organized UI: Action buttons have been separated into another function, keeping the interface neat and less cluttered.

* **Created Placeholder for Summary Details**
In the `SummaryDetailsShimmerLoader.kt` file, new functions have been added to show shimmer loading placeholders specifically for summary details.

* **Implemented Loading Progress Tracking**
A new property, `progressState`, has been added to track the loading progress. This will help in understanding how far along the content is in the loading process.

* **Updated Summary Details View**
Changes to `SummaryDetailsViewModel.kt` include:
    * Better loading indication: It now shows the loading state when fetching the summary details.
    * Improved state handling: After the successful loading of the summary details, it correctly updates the `summary` property and sets the `progressState` to `Hide`.

* **Improved Shared Message Content**
The `summary_details_share_message` resource has been updated to provide an improved and more general message for sharing a summary. This will make the shared message more user-friendly and appealing.


## Video recording
[Screen_recording_20230922_063549.webm](https://github.com/rygelouv/Tanga/assets/7549316/3ee24a01-72b7-427b-85f9-c5897e9539e0)
