### PR TITLE
Play audio in background

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,6 +150,8 @@ dependencies {
 
     // Media
     implementation(libs.media3.exoplayer)
+    implementation(libs.media3.session)
+    implementation(libs.media3.common)
 
     // Logging
     implementation(libs.timber)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         <service
             android:name=".feature.audioplayer.PlaybackService"
             android:foregroundServiceType="mediaPlayback"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService"/>
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -28,22 +31,31 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
+
+        <service
+            android:name=".feature.audioplayer.PlaybackService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService"/>
+            </intent-filter>
+        </service>
     
-    <!-- Required: set your sentry.io project identifier (DSN) -->
-    <meta-data android:name="io.sentry.dsn" android:value="https://d3da1b415af3e6a3482e2c7fee0740a0@o4506014737104896.ingest.sentry.io/4506014893342720" />
+        <!-- Required: set your sentry.io project identifier (DSN) -->
+        <meta-data android:name="io.sentry.dsn" android:value="https://d3da1b415af3e6a3482e2c7fee0740a0@o4506014737104896.ingest.sentry.io/4506014893342720" />
 
-    <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
-    <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
-    <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="true" />
-    <!-- enable screenshot for crashes (could contain sensitive/PII data) -->
-    <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
-    <!-- enable view hierarchy for crashes -->
-    <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
+        <!-- enable automatic breadcrumbs for user interactions (clicks, swipes, scrolls) -->
+        <meta-data android:name="io.sentry.traces.user-interaction.enable" android:value="true" />
+        <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="true" />
+        <!-- enable screenshot for crashes (could contain sensitive/PII data) -->
+        <meta-data android:name="io.sentry.attach-screenshot" android:value="true" />
+        <!-- enable view hierarchy for crashes -->
+        <meta-data android:name="io.sentry.attach-view-hierarchy" android:value="true" />
 
-    <!-- enable the performance API by setting a sample-rate, adjust in production env -->
-    <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
-    <!-- enable profiling when starting transactions, adjust in production env -->
-    <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
-</application>
+        <!-- enable the performance API by setting a sample-rate, adjust in production env -->
+        <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
+        <!-- enable profiling when starting transactions, adjust in production env -->
+        <meta-data android:name="io.sentry.traces.profiling.sample-rate" android:value="1.0" />
+    </application>
 
 </manifest>

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/AudioPlayerModule.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/AudioPlayerModule.kt
@@ -1,7 +1,10 @@
 package app.books.tanga.feature.audioplayer
 
+import android.content.ComponentName
 import android.content.Context
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,5 +20,11 @@ class AudioPlayerModule {
     ): ExoPlayer = ExoPlayer.Builder(context).build()
 
     @Provides
-    fun providePlayerController(exoPlayerController: ExoPlayerController): PlayerController = exoPlayerController
+    fun providePlayerController(playerControllerImpl: PlayerControllerImpl): PlayerController = playerControllerImpl
+
+    @Provides
+    fun provideMediaControllerBuilder(@ApplicationContext context: Context): MediaController.Builder {
+        val sessionToken = SessionToken(context, ComponentName(context, PlaybackService::class.java))
+        return MediaController.Builder(context, sessionToken)
+    }
 }

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/AudioTrack.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/AudioTrack.kt
@@ -1,19 +1,37 @@
 package app.books.tanga.feature.audioplayer
 
+import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 
 /**
  * Represents an audio track.
  *
  * @param id The unique identifier of the track.
+ * @param title The title of the track. The book title.
+ * @param author The author of the track. The book author.
+ * @param coverUrl The URL of the cover image of the book.
  * @param url The URL of the track.
  */
 data class AudioTrack(
     val id: String,
-    val url: String
+    val url: String,
+    val title: String,
+    val author: String,
+    val coverUrl: String
 )
 
 /**
  * Converts an [AudioTrack] to a [MediaItem].
  */
-fun AudioTrack.toMediaItem(): MediaItem = MediaItem.fromUri(url)
+fun AudioTrack.toMediaItem(): MediaItem = MediaItem.Builder()
+    .setMediaId(id)
+    .setUri(url)
+    .setMediaMetadata(
+        MediaMetadata.Builder()
+            .setTitle(title)
+            .setArtist(author)
+            .setArtworkUri(coverUrl.toUri())
+            .build()
+    )
+    .build()

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/PlaybackService.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/PlaybackService.kt
@@ -1,0 +1,43 @@
+package app.books.tanga.feature.audioplayer
+
+import android.content.Intent
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import javax.inject.Inject
+
+class PlaybackService : MediaSessionService() {
+    private var mediaSession: MediaSession? = null
+
+    @Inject
+    lateinit var player: ExoPlayer
+
+    override fun onCreate() {
+        super.onCreate()
+        player = ExoPlayer.Builder(this).build()
+        mediaSession = MediaSession.Builder(this, player).build()
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        if (!player.playWhenReady ||
+            player.mediaItemCount == 0 ||
+            player.playbackState == Player.STATE_ENDED
+        ) {
+            // Stop the service if not playing, continue playing in the background
+            // otherwise.
+            stopSelf()
+        }
+    }
+
+    override fun onDestroy() {
+        mediaSession?.run {
+            player.release()
+            release()
+            mediaSession = null
+        }
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerActions.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerActions.kt
@@ -7,7 +7,7 @@ interface PlayerActions {
     /**
      * Called when the play/pause button is clicked.
      */
-    fun onPlayPause()
+    fun onPlayPause(track: AudioTrack)
 
     /**
      * Called when the forward button is clicked.

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
@@ -2,7 +2,8 @@ package app.books.tanga.feature.audioplayer
 
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaController
+import com.google.common.util.concurrent.MoreExecutors
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -41,10 +42,10 @@ interface PlayerController : PlayerActions {
 }
 
 /**
- * Concrete implementation of PlayerController using ExoPlayer as the media playback engine.
+ * Concrete implementation of PlayerController using [MediaController] as the media playback engine.
  */
-class ExoPlayerController @Inject constructor(
-    private val player: ExoPlayer
+class PlayerControllerImpl @Inject constructor(
+    controllerBuilder: MediaController.Builder
 ) : PlayerController, Player.Listener {
     /** A state flow that emits the current playback state of the player. */
     private val _playbackState = MutableStateFlow(PlaybackState())
@@ -56,8 +57,14 @@ class ExoPlayerController @Inject constructor(
     /** Coroutine scope provided during initialization. */
     private var scope: CoroutineScope? = null
 
+    private lateinit var player: Player
+
     init {
-        player.addListener(this)
+        val controllerFuture = controllerBuilder.buildAsync()
+        controllerFuture.addListener({
+            player = controllerFuture.get()
+            player.addListener(this)
+        }, MoreExecutors.directExecutor())
     }
 
     /**
@@ -83,17 +90,65 @@ class ExoPlayerController @Inject constructor(
         playbackStateUpdateJob?.cancel()
     }
 
+    /**
+     * Initializes the player with the provided track and starts playback based on the current state of the player.
+     */
     override fun initPlayer(
         track: AudioTrack,
         scope: CoroutineScope
     ) {
         this.scope = scope
+
+        val mediaItemId = player.currentMediaItem?.mediaId
+        when {
+            // If the player is already playing the same track, setup observation of the playback state.
+            player.isPlaying && mediaItemId == track.id -> {
+                startPeriodicPlaybackUpdates()
+                updatePlaybackStateBasedOnPlayer(player.playbackState)
+            }
+            // If the player was playing a track and the user wants to play a new one,
+            // do nothing until the user plays the new track.
+            player.isPlaying && mediaItemId != track.id -> return
+            // If player is not playing, prepare the new track.
+            else -> prepareNewTrack(track)
+        }
+    }
+
+    private fun prepareNewTrack(track: AudioTrack) {
         player.setMediaItem(track.toMediaItem())
         player.prepare()
     }
 
-    override fun onPlayPause() {
-        if (player.playbackState == Player.STATE_IDLE) player.prepare()
+    /**
+     * Handles the play/pause action based on the current state of the player.
+     * If a different track is selected, it stops the current track and starts the new one.
+     * If the player is idle, it prepares the track and starts playback.
+     * If the player is playing, it pauses the playback.
+     * If the player is paused, it resumes playback.
+     */
+    override fun onPlayPause(track: AudioTrack) {
+        when {
+            player.currentMediaItem?.mediaId != track.id -> handleNewTrack(track)
+            player.playbackState == Player.STATE_IDLE -> handleIdleState()
+            else -> togglePlayback()
+        }
+    }
+
+    private fun handleNewTrack(track: AudioTrack) {
+        stopPeriodicPlaybackUpdates()
+        player.stop()
+        prepareNewTrack(track)
+        player.playWhenReady = true
+        startPeriodicPlaybackUpdates()
+    }
+
+    private fun handleIdleState() {
+        player.prepare()
+        player.playWhenReady = true
+        startPeriodicPlaybackUpdates()
+    }
+
+    private fun togglePlayback() {
         player.playWhenReady = player.playWhenReady.not()
         if (player.playWhenReady) {
             startPeriodicPlaybackUpdates()

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
@@ -41,9 +41,12 @@ interface PlayerController : PlayerActions {
     }
 }
 
+private const val SECOND_IN_MILLIS = 1000
+
 /**
  * Concrete implementation of PlayerController using [MediaController] as the media playback engine.
  */
+@Suppress("TooManyFunctions")
 class PlayerControllerImpl @Inject constructor(
     controllerBuilder: MediaController.Builder
 ) : PlayerController, Player.Listener {
@@ -78,7 +81,7 @@ class PlayerControllerImpl @Inject constructor(
                         it.copy(position = player.currentPosition, duration = player.duration)
                     }
                     // Calculate delay to the next second boundary
-                    val delayMillis = 1000 - (player.currentPosition % 1000)
+                    val delayMillis = SECOND_IN_MILLIS - (player.currentPosition % SECOND_IN_MILLIS)
                     delay(delayMillis)
                 } while (playbackStateUpdateJob?.isActive == true &&
                     playbackState.value.state == PlayerState.PLAYING

--- a/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
+++ b/app/src/main/java/app/books/tanga/feature/audioplayer/PlayerController.kt
@@ -74,6 +74,7 @@ class PlayerControllerImpl @Inject constructor(
      * Starts a coroutine that updates the playback state at regular intervals.
      */
     private fun startPeriodicPlaybackUpdates() {
+        playbackStateUpdateJob?.cancel()
         playbackStateUpdateJob =
             scope?.launch {
                 do {
@@ -91,6 +92,7 @@ class PlayerControllerImpl @Inject constructor(
 
     private fun stopPeriodicPlaybackUpdates() {
         playbackStateUpdateJob?.cancel()
+        playbackStateUpdateJob = null
     }
 
     /**

--- a/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioScreen.kt
+++ b/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioScreen.kt
@@ -17,12 +17,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Surface
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -44,6 +44,7 @@ import app.books.tanga.coreui.components.TangaAsyncImage
 import app.books.tanga.coreui.icons.TangaIcons
 import app.books.tanga.coreui.theme.LocalSpacing
 import app.books.tanga.entity.SummaryId
+import app.books.tanga.feature.audioplayer.AudioTrack
 import app.books.tanga.feature.audioplayer.PlaybackState
 import app.books.tanga.feature.audioplayer.PlayerActions
 import app.books.tanga.feature.audioplayer.PlayerState
@@ -83,6 +84,7 @@ fun PlaySummaryAudioScreen(
                 coverUrl = state.coverUrl,
                 duration = state.duration,
                 playbackState = state.playbackState,
+                audioTrack = state.audioTrack,
                 actions = actions
             )
         }
@@ -114,6 +116,7 @@ fun PlaySummaryAudioContent(
     title: String? = null,
     author: String? = null,
     duration: String? = null,
+    audioTrack: AudioTrack? = null,
     playbackState: PlaybackState? = null
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -172,7 +175,7 @@ fun PlaySummaryAudioContent(
                 Spacer(modifier = Modifier.height(LocalSpacing.current.extraExtraLarge))
                 AudioBar(playbackState = playbackState, duration = duration) { actions.onSeekBarPositionChanged(it) }
                 Spacer(modifier = Modifier.height(LocalSpacing.current.extraLarge))
-                PlaybackControls(playbackState = playbackState, actions = actions)
+                PlaybackControls(playbackState = playbackState, audioTrack = audioTrack, actions = actions)
             }
         }
         TangaAsyncImage(
@@ -191,6 +194,7 @@ fun PlaySummaryAudioContent(
 @Composable
 private fun PlaybackControls(
     actions: PlayerActions,
+    audioTrack: AudioTrack? = null,
     playbackState: PlaybackState? = null
 ) {
     Row(
@@ -207,7 +211,9 @@ private fun PlaybackControls(
             )
         }
         IconButton(
-            onClick = { actions.onPlayPause() },
+            onClick = {
+                audioTrack?.let { actions.onPlayPause(it) }
+            },
             modifier = Modifier
                 .size(76.dp)
                 .clip(CircleShape)

--- a/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioUiContract.kt
+++ b/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioUiContract.kt
@@ -1,6 +1,7 @@
 package app.books.tanga.feature.listen
 
 import app.books.tanga.errors.UiError
+import app.books.tanga.feature.audioplayer.AudioTrack
 import app.books.tanga.feature.audioplayer.PlaybackState
 
 data class PlaySummaryAudioUiState(
@@ -10,5 +11,6 @@ data class PlaySummaryAudioUiState(
     val coverUrl: String? = null,
     val duration: String? = null,
     val playbackState: PlaybackState? = null,
-    val error: UiError? = null
+    val error: UiError? = null,
+    val audioTrack: AudioTrack? = null
 )

--- a/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioViewModel.kt
+++ b/app/src/main/java/app/books/tanga/feature/listen/PlaySummaryAudioViewModel.kt
@@ -3,6 +3,7 @@ package app.books.tanga.feature.listen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.books.tanga.data.download.DownloadUrlGenerator
+import app.books.tanga.entity.Summary
 import app.books.tanga.entity.SummaryId
 import app.books.tanga.errors.toUiError
 import app.books.tanga.feature.audioplayer.AudioTrack
@@ -59,8 +60,11 @@ class PlaySummaryAudioViewModel @Inject constructor(
                         )
                     }
                     audioUrl?.let {
-                        val audioTrack = AudioTrack(id = summary.id.value, url = it)
+                        val audioTrack = summary.toAudioTrack(it)
                         playerController.initPlayer(audioTrack, viewModelScope)
+                        _state.update { state ->
+                            state.copy(audioTrack = audioTrack)
+                        }
                     }
                 }.onFailure {
                     Timber.e("Error loading summary with id: $summaryId", it)
@@ -76,3 +80,11 @@ class PlaySummaryAudioViewModel @Inject constructor(
         playerController.releasePlayer()
     }
 }
+
+fun Summary.toAudioTrack(url: String): AudioTrack = AudioTrack(
+    id = id.value,
+    url = url,
+    title = title,
+    author = author,
+    coverUrl = coverImageUrl
+)

--- a/app/src/test/java/app/books/tanga/feature/audioplayer/PlaySummaryAudioViewModelTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/audioplayer/PlaySummaryAudioViewModelTest.kt
@@ -1,11 +1,7 @@
-package app.books.tanga.feature
+package app.books.tanga.feature.audioplayer
 
 import app.books.tanga.data.download.DownloadUrlGenerator
 import app.books.tanga.entity.SummaryId
-import app.books.tanga.feature.audioplayer.AudioTrack
-import app.books.tanga.feature.audioplayer.PlaybackState
-import app.books.tanga.feature.audioplayer.PlayerController
-import app.books.tanga.feature.audioplayer.PlayerState
 import app.books.tanga.feature.listen.PlaySummaryAudioViewModel
 import app.books.tanga.feature.summary.SummaryInteractor
 import app.books.tanga.fixtures.Fixtures
@@ -68,7 +64,7 @@ class PlaySummaryAudioViewModelTest {
     fun `Load summary successfully updates viewModel state and initializes player`() = runTest {
         val summaryId = SummaryId("1")
         val summary = Fixtures.dummySummary1
-        val audioTrack = AudioTrack(id = summary.id.value, url = "http://example.com/audio.mp3")
+        val audioTrack = Fixtures.audioTrack1
 
         coEvery { summaryInteractor.getSummary(summaryId) } returns Result.success(summary)
         coEvery { playerController.initPlayer(audioTrack, any()) } just Runs

--- a/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MainCoroutineDispatcherExtension::class)
 @ExperimentalCoroutinesApi
-class PlayerControllerImplTest {
+class PlayerControllerTest {
 
     private lateinit var playerControllerImpl: PlayerControllerImpl
     private lateinit var mockPlayer: Player

--- a/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
@@ -1,0 +1,137 @@
+package app.books.tanga.feature.audioplayer
+
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import app.books.tanga.fixtures.Fixtures
+import app.books.tanga.rule.MainCoroutineDispatcherExtension
+import com.google.common.util.concurrent.ListenableFuture
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MainCoroutineDispatcherExtension::class)
+@ExperimentalCoroutinesApi
+class PlayerControllerImplTest {
+
+    private lateinit var playerControllerImpl: PlayerControllerImpl
+    private lateinit var mockPlayer: Player
+    private lateinit var mockControllerBuilder: MediaController.Builder
+    private lateinit var mockControllerFuture: ListenableFuture<MediaController>
+
+    @BeforeEach
+    fun setup() {
+        mockPlayer = mockk(relaxed = true)
+        mockControllerBuilder = mockk()
+        mockControllerFuture = mockk()
+
+        every { mockControllerBuilder.buildAsync() } returns mockControllerFuture
+        every { mockControllerFuture.addListener(any(), any()) } just Runs
+        every { mockControllerFuture.get() } returns mockPlayer as MediaController
+
+        playerControllerImpl = PlayerControllerImpl(mockControllerBuilder)
+    }
+
+    @Test
+    fun `initPlayer should start periodic updates when player is already playing the same track`() = runTest {
+        val track = Fixtures.audioTrack1
+        every { mockPlayer.isPlaying } returns true
+        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+
+        playerControllerImpl.initPlayer(track, this)
+
+        advanceTimeBy(2000)
+        val state = playerControllerImpl.playbackState.first()
+        assertEquals(PlayerState.PLAYING, state.state)
+    }
+
+    @Test
+    fun `initPlayer should not prepare new track when player is playing a different track`() = runTest {
+        val track = Fixtures.audioTrack1
+        every { mockPlayer.isPlaying } returns true
+        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+
+        playerControllerImpl.initPlayer(track, this)
+
+        verify(exactly = 0) { mockPlayer.setMediaItem(any()) }
+        verify(exactly = 0) { mockPlayer.prepare() }
+    }
+
+    @Test
+    fun `onPlayPause should handle new track correctly`() {
+        val track = Fixtures.audioTrack1
+        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+
+        playerControllerImpl.onPlayPause(track)
+
+        verify { mockPlayer.stop() }
+        verify { mockPlayer.setMediaItem(any()) }
+        verify { mockPlayer.prepare() }
+        verify { mockPlayer.playWhenReady = true }
+    }
+
+    @Test
+    fun `onPlayPause should toggle playback for current track`() {
+        val track = Fixtures.audioTrack1
+        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        every { mockPlayer.playbackState } returns Player.STATE_READY
+        every { mockPlayer.playWhenReady } returns false
+
+        playerControllerImpl.onPlayPause(track)
+
+        verify { mockPlayer.playWhenReady = true }
+    }
+
+    @Test
+    fun `onForward should seek forward by SEEK_INTERVAL_MS`() {
+        every { mockPlayer.currentPosition } returns 5000
+
+        playerControllerImpl.onForward()
+
+        verify { mockPlayer.seekTo(15000) }
+    }
+
+    @Test
+    fun `onBackward should seek backward by SEEK_INTERVAL_MS`() {
+        every { mockPlayer.currentPosition } returns 15000
+
+        playerControllerImpl.onBackward()
+
+        verify { mockPlayer.seekTo(5000) }
+    }
+
+    @Test
+    fun `onSeekBarPositionChanged should seek to the specified position`() {
+        playerControllerImpl.onSeekBarPositionChanged(20000)
+
+        verify { mockPlayer.seekTo(20000) }
+    }
+
+    @Test
+    fun `updatePlaybackStateBasedOnPlayer should update state correctly`() = runTest {
+        every { mockPlayer.playWhenReady } returns true
+
+        playerControllerImpl.onPlaybackStateChanged(Player.STATE_READY)
+
+        val state = playerControllerImpl.playbackState.first()
+        assertEquals(PlayerState.PLAYING, state.state)
+    }
+
+    @Test
+    fun `releasePlayer should stop updates and release player`() {
+        playerControllerImpl.releasePlayer()
+
+        verify { mockPlayer.removeListener(any()) }
+        verify { mockPlayer.release() }
+    }
+}

--- a/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/audioplayer/PlayerControllerTest.kt
@@ -4,12 +4,12 @@ import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import app.books.tanga.fixtures.Fixtures
 import app.books.tanga.rule.MainCoroutineDispatcherExtension
+import app.cash.turbine.test
 import com.google.common.util.concurrent.ListenableFuture
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import java.util.concurrent.Executor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceTimeBy
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class PlayerControllerTest {
 
     private lateinit var playerControllerImpl: PlayerControllerImpl
-    private lateinit var mockPlayer: Player
+    private lateinit var mockPlayer: MediaController
     private lateinit var mockControllerBuilder: MediaController.Builder
     private lateinit var mockControllerFuture: ListenableFuture<MediaController>
 
@@ -35,33 +35,73 @@ class PlayerControllerTest {
         mockControllerFuture = mockk()
 
         every { mockControllerBuilder.buildAsync() } returns mockControllerFuture
-        every { mockControllerFuture.addListener(any(), any()) } just Runs
-        every { mockControllerFuture.get() } returns mockPlayer as MediaController
+        every { mockControllerFuture.get() } returns mockPlayer
+
+        // Mock the addListener behavior
+        every {
+            mockControllerFuture.addListener(any(), any())
+        } answers {
+            val runnable = firstArg<Runnable>()
+            val executor = secondArg<Executor>()
+            executor.execute(runnable)
+        }
 
         playerControllerImpl = PlayerControllerImpl(mockControllerBuilder)
+
+        // Ensure player is initialized
+        verifyPlayerInitialized()
+
+        playerControllerImpl = PlayerControllerImpl(mockControllerBuilder)
+    }
+
+    private fun verifyPlayerInitialized() {
+        verify(exactly = 1) {
+            mockControllerFuture.addListener(any(), any())
+        }
+        verify(exactly = 1) {
+            mockPlayer.addListener(playerControllerImpl)
+        }
     }
 
     @Test
     fun `initPlayer should start periodic updates when player is already playing the same track`() = runTest {
         val track = Fixtures.audioTrack1
         every { mockPlayer.isPlaying } returns true
-        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        every { mockPlayer.currentMediaItem } returns track.toMediaItem()
         every { mockPlayer.playbackState } returns Player.STATE_READY
+        // We check player in a paused state to avoid starting the updates which will block the test
+        every { mockPlayer.playWhenReady } returns false
 
         playerControllerImpl.initPlayer(track, this)
 
+        // Advance time to trigger the first update
         advanceTimeBy(2000)
-        val state = playerControllerImpl.playbackState.first()
-        assertEquals(PlayerState.PLAYING, state.state)
+        playerControllerImpl.playbackState.test {
+            val state = expectMostRecentItem()
+            assertEquals(PlayerState.PAUSE, state.state)
+        }
+    }
+
+    @Test
+    fun `initPlayer should prepare new track when player is not playing`() = runTest {
+        val track = Fixtures.audioTrack1
+        every { mockPlayer.isPlaying } returns false
+        every { mockPlayer.currentMediaItem } returns track.toMediaItem()
+
+        playerControllerImpl.initPlayer(track, this)
+
+        verify(exactly = 1) { mockPlayer.setMediaItem(any()) }
+        verify(exactly = 1) { mockPlayer.prepare() }
     }
 
     @Test
     fun `initPlayer should not prepare new track when player is playing a different track`() = runTest {
-        val track = Fixtures.audioTrack1
+        val track1 = Fixtures.audioTrack1
+        val track2 = Fixtures.audioTrack2
         every { mockPlayer.isPlaying } returns true
-        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        every { mockPlayer.currentMediaItem } returns track2.toMediaItem()
 
-        playerControllerImpl.initPlayer(track, this)
+        playerControllerImpl.initPlayer(track1, this)
 
         verify(exactly = 0) { mockPlayer.setMediaItem(any()) }
         verify(exactly = 0) { mockPlayer.prepare() }
@@ -69,10 +109,11 @@ class PlayerControllerTest {
 
     @Test
     fun `onPlayPause should handle new track correctly`() {
-        val track = Fixtures.audioTrack1
-        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        val currentTrack = Fixtures.audioTrack1
+        val newTrack = Fixtures.audioTrack2
+        every { mockPlayer.currentMediaItem } returns currentTrack.toMediaItem()
 
-        playerControllerImpl.onPlayPause(track)
+        playerControllerImpl.onPlayPause(newTrack)
 
         verify { mockPlayer.stop() }
         verify { mockPlayer.setMediaItem(any()) }
@@ -83,7 +124,7 @@ class PlayerControllerTest {
     @Test
     fun `onPlayPause should toggle playback for current track`() {
         val track = Fixtures.audioTrack1
-        every { mockPlayer.currentMediaItem?.mediaId } returns "1"
+        every { mockPlayer.currentMediaItem } returns track.toMediaItem()
         every { mockPlayer.playbackState } returns Player.STATE_READY
         every { mockPlayer.playWhenReady } returns false
 

--- a/app/src/test/java/app/books/tanga/feature/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/library/LibraryViewModelTest.kt
@@ -1,10 +1,7 @@
-package app.books.tanga.feature
+package app.books.tanga.feature.library
 
 import app.books.tanga.common.ui.ProgressState
 import app.books.tanga.entity.Favorite
-import app.books.tanga.feature.library.FavoriteInteractor
-import app.books.tanga.feature.library.LibraryViewModel
-import app.books.tanga.feature.library.toFavoriteUi
 import app.books.tanga.fixtures.Fixtures
 import app.books.tanga.rule.MainCoroutineDispatcherExtension
 import app.cash.turbine.test

--- a/app/src/test/java/app/books/tanga/feature/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/app/books/tanga/feature/onboarding/OnboardingViewModelTest.kt
@@ -1,7 +1,6 @@
-package app.books.tanga.feature
+package app.books.tanga.feature.onboarding
 
 import app.books.tanga.data.preferences.DefaultPrefDataStoreRepository
-import app.books.tanga.feature.onboarding.OnboardingViewModel
 import app.books.tanga.rule.MainCoroutineDispatcherExtension
 import app.books.tanga.tracking.AnalyticsTracker
 import io.mockk.coVerify

--- a/app/src/test/java/app/books/tanga/fixtures/Fixtures.kt
+++ b/app/src/test/java/app/books/tanga/fixtures/Fixtures.kt
@@ -12,6 +12,7 @@ import app.books.tanga.entity.Summary
 import app.books.tanga.entity.SummaryId
 import app.books.tanga.entity.User
 import app.books.tanga.entity.UserId
+import app.books.tanga.feature.audioplayer.AudioTrack
 import app.books.tanga.firestore.FirestoreDatabase
 import com.google.firebase.Timestamp
 import java.util.Date
@@ -134,5 +135,21 @@ object Fixtures {
             formattedValue = "$99.99",
             currency = "USD"
         )
+    )
+
+    val audioTrack1 = AudioTrack(
+        id = "1",
+        url = "http://example.com/audio.mp3",
+        title = "Content1",
+        author = "Author1",
+        coverUrl = "http://example.com/image.png"
+    )
+
+    val audioTrack2 = AudioTrack(
+        id = "2",
+        url = "http://example.com/audio.mp3",
+        title = "Content2",
+        author = "Author2",
+        coverUrl = "http://example.com/image.png"
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ detekt-rules-compose = "1.3.0"
 kotlin-immutable-collections-version = "0.3.6"
 
 # Media https://developer.android.com/guide/topics/media/exoplayer
-exoplayer-media3-version = "1.4.0"
+media3-version = "1.4.0"
 
 # Logging
 # https://github.com/JakeWharton/timber/releases
@@ -157,7 +157,9 @@ kotlin-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coro
 android-gms-play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "play-services-auth-version" }
 
 # Media
-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "exoplayer-media3-version" }
+media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3-version" }
+media3-session = { module = "androidx.media3:media3-session", version.ref = "media3-version" }
+media3-common = { module = "androidx.media3:media3-common", version.ref = "media3-version" }
 
 # Logging
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber-version" }


### PR DESCRIPTION
---
### 🚀 Description
Right now in version 1.1.x when the user leaves the player page the audio stops playing. We want to be able to continue playing the audio even when the user leaves the player. And we can do this in two phases. Step is playing audio in background services and second is adding a mini player. 

https://developer.android.com/media/media3/session/background-playback
https://developer.android.com/media/media3/session/connect-to-media-app#create-controller
https://developer.android.com/media/media3/exoplayer/listening-to-player-events
https://developer.android.com/media/implement/playback-app

This commit introduces a new audio player implementation using Media3.
- Migrated from ExoPlayer to Media3 for audio playback.
- Implemented a foreground service for background playback.
- Updated the UI to display track information and playback controls.
- Added support for seeking and playback state updates.
- Refactored the `PlayerController` interface and its implementation
- Added unit tests for the new `PlayerControllerImpl`.
- Updated dependencies to include Media3 libraries.
- Updated the `AudioTrack` class to include track metadata.
- Updated the `PlaySummaryAudioViewModel` to handle audio track information.
- Updated the `PlaySummaryAudioScreen` to display track metadata and use the new `PlayerController` actions.

**Issue (if applicable):**

### 🖼 Screenshots/Videos (if applicable)

- After:
[Attach after screenshot or link to video]

https://github.com/user-attachments/assets/2355bb04-14d0-48b2-9f70-cca8d4c91f36


### 📦 Dependencies

- [x] Added new dependencies? List:
- [ ] Updated existing?

### 🧪 Testing
- Open a summary, play audio and leave the player scren

### 📱 Checklist
- [ ] Tested on all supported devices and OS versions
- [ ] UI/UX conforms to project design guidelines
- [x] Unit/integration tests added
- [ ] Relevant documentation updated (e.g., README, Wiki, etc.)
- [ ] Checked linter on local.

---
